### PR TITLE
fix(readme): fix incorrect flash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ riscv32-esp-elf-gdb build/critical_fw_esp32c3.elf -ex "target remote :1234" -ex 
 By default, the flashing process assumes the board is connected to /dev/ttyUSB0. The port can be set with `-DESP_PORT`.
 
 ```sh
-ninja -C build flash -DESP_PORT=/dev/ttyUSB0
+export ESP_PORT=/dev/ttyUSB0
+ninja -C build flash
 ```
 
 ## Watchdog

--- a/cmake/project.cmake
+++ b/cmake/project.cmake
@@ -15,8 +15,17 @@ endif()
 
 message("Building BIST project for ${SOC_TARGET}")
 
+if (DEFINED ENV{IDF_PATH})
+    set(IDF_PATH $ENV{IDF_PATH})
+    include(${IDF_PATH}/tools/cmake/version.cmake)
+    if (NOT (IDF_VERSION_MAJOR EQUAL 5 AND IDF_VERSION_MINOR EQUAL 1 AND IDF_VERSION_PATCH EQUAL 4))
+        message(FATAL_ERROR "Unsupported ESP-IDF version. Required: v5.1.4, Found: v${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}.${IDF_VERSION_PATCH}")
+    endif()
+else()
+    set(IDF_PATH ${MODULES_PATH}/esp-idf)
+endif()
+
 set(MODULES_PATH ${BIST_ROOT_DIR}/modules)
-set(IDF_PATH ${MODULES_PATH}/esp-idf)
 set(MCUBOOT_PATH ${MODULES_PATH}/mcuboot)
 set(MCUBOOT_BIN_PATH ${MODULES_PATH}/mcuboot/boot/espressif/build)
 


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

* fix incorrect flash command in readme (ninja: invalid option -- 'D'")
* make it possiable to work with already installed ESP-IDF

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
